### PR TITLE
02 - containerize the mmdb app

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,55 @@ Browse to
 * http://localhost:8002/swagger-ui/ for a Swagger user interface to the dynamic schema view, or
 * http://localhost:8002/openapi for the schema view's OpenAPI specification document.
 
+
+# Run app with docker
+
+### .env settings
+
+##### Related settings
+* COMPOSE_PROJECT_NAME=mmdb
+  <br/> defines the prefix of docker container name
+* COMPOSE_FILE
+  <br/> defines the compose file to build the service
+* MMDB_BRANCH
+  <br/> defines the github branch to build from when use docker-compose.override.yaml
+* MMDB_PORT=8002
+  <br/> defines the port to run the app, defaults to 8002
+* SQL_DATABASE=mmdb
+* SQL_HOST
+* SQL_PORT
+* SQL_USER
+* SQL_PASSWORD
+
+
+##### Run with code on local dev machine and mysql on host server
+
+* COMPOSE_FILE=docker/docker-compose.yaml;docker/docker-compose.dev.override.yaml
+* SQL_HOST=host.docker.internal
+
+##### Run with code on remote github and mysql on host server
+* COMPOSE_FILE=docker/docker-compose.yaml;docker/docker-compose.override.yaml
+* SQL_HOST=host.docker.internal
+* MMDB_BRANCH=the_remote_branch_name (defaults to master)
+
+##### Run with mysql as a docker service
+* COMPOSE_FILE=docker/docker-compose.yaml;docker/docker-compose.dev.override.yaml;docker/docker-compose.mysql.override.yaml
+<br/>or</br> 
+* COMPOSE_FILE=docker/docker-compose.yaml;docker/docker-compose.override.yaml;docker/docker-compose.mysql.override.yaml
+* SQL_HOST=mysql
+
+
+### Build and run
+```
+$ docker-compose build
+$ docker-compose run
+```
+Then browse to http://localhost:8002 (or the port configured)
+
+
+### Apply db migrations
+Manually ssh to the mmdb container and run the migrate command
+```
+$ docker exec -it mmdb_mmdb_1 /bin/sh
+# django-admin migrate --settings=mmdb.settings
+```

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Browse to
 * http://localhost:8002/openapi for the schema view's OpenAPI specification document.
 
 
-# Run app with docker
+# Run App with Docker
 
 ### .env settings
 
@@ -88,7 +88,7 @@ Browse to
 ### Build and run
 ```
 $ docker-compose build
-$ docker-compose run
+$ docker-compose up
 ```
 Then browse to http://localhost:8002 (or the port configured)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.8-alpine
+
+RUN apk add --no-cache \
+        g++ \
+        git \
+        libffi-dev \
+        libxslt-dev \
+        mariadb-dev \
+        jpeg-dev \
+        zlib-dev \
+        build-base
+
+RUN python -m pip install --upgrade pip
+
+COPY . /app/.
+WORKDIR /app
+
+RUN cd /app & \
+    pip --no-cache-dir install -r requirements.txt
+
+RUN rm -f .env \
+ && rm -rf collected_static \
+ && rm -rf media \
+ && django-admin collectstatic --noinput --settings=mmdb.settings
+
+CMD gunicorn mmdb.wsgi -c mmdb/gunicorn.py
+
+EXPOSE ${MMDB_PORT}

--- a/docker/docker-compose.dev.override.yaml
+++ b/docker/docker-compose.dev.override.yaml
@@ -1,0 +1,23 @@
+version: "3.1"
+
+services:
+  mmdb:
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile
+    image: mmdb
+    restart: unless-stopped
+    environment:
+      ALLOWED_HOSTS: ${ALLOWED_HOSTS:-*}
+      DEBUG: ${DEBUG:-true}
+      MMDB_ALLOWED_HOSTS: ${MMDB_ALLOWED_HOSTS:-*}
+      MMDB_DEBUG: ${MMDB_DEBUG:-true}
+      MMDB_PORT: ${MMDB_PORT:-8002}
+      MMDB_SECRET_KEY: ${MMDB_SECRET_KEY}
+      SQL_DATABASE: ${SQL_DATABASE:-mmdb}
+      SQL_HOST: ${SQL_HOST:-localhost}
+      SQL_PORT: ${SQL_PORT:-3306}
+      SQL_USER: ${SQL_USER:-mmdb}
+      SQL_PASSWORD: ${SQL_PASSWORD}
+      GUNICORN_OPTS: ${GUNICORN_OPTS:-}
+      MMDB_GUNICORN_OPTS: ${GUNICORN_OPTS:-}

--- a/docker/docker-compose.mysql.override.yaml
+++ b/docker/docker-compose.mysql.override.yaml
@@ -1,0 +1,27 @@
+version: "3.1"
+
+volumes:
+  mysqldata:
+
+services:
+  mysql:
+    image: mysql:5.7.23
+    restart: unless-stopped
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      MYSQL_DATABASE: ${SQL_DATABASE:-mmdb}
+      MYSQL_ROOT_PASSWORD: ${SQL_PASSWORD:-}
+      MYSQL_TCP_PORT: ${SQL_PORT:-3306}
+    ports:
+      - ${SQL_PORT:-3306}:${SQL_PORT:-3306}
+    volumes:
+      - mysqldata:/var/lib/mysql
+    entrypoint: >
+      sh -c "
+        echo \"
+          USE mysql;
+          UPDATE user SET user='${SQL_USER:-root}' WHERE user='root';
+          FLUSH PRIVILEGES;
+        \" > /docker-entrypoint-initdb.d/init.sql \
+        && docker-entrypoint.sh --character-set-server=utf8 --ssl=0
+      "

--- a/docker/docker-compose.mysql.override.yaml
+++ b/docker/docker-compose.mysql.override.yaml
@@ -23,5 +23,5 @@ services:
           UPDATE user SET user='${SQL_USER:-root}' WHERE user='root';
           FLUSH PRIVILEGES;
         \" > /docker-entrypoint-initdb.d/init.sql \
-        && docker-entrypoint.sh --character-set-server=utf8 --ssl=0
+        && docker-entrypoint.sh --character-set-server=utf8mb4 --ssl=0
       "

--- a/docker/docker-compose.override.yaml
+++ b/docker/docker-compose.override.yaml
@@ -1,0 +1,23 @@
+version: "3.1"
+
+services:
+  mmdb:
+    build:
+      context: https://github.com/HumanExposure/MMDB.git#${MMDB_BRANCH:-master}
+      dockerfile: docker/Dockerfile
+    image: mmdb
+    restart: unless-stopped
+    environment:
+      ALLOWED_HOSTS: ${ALLOWED_HOSTS:-.epa.gov}
+      DEBUG: ${DEBUG:-false}
+      MMDB_ALLOWED_HOSTS: ${MMDB_ALLOWED_HOSTS:-.epa.gov}
+      MMDB_DEBUG: ${MMDB_DEBUG:-false}
+      MMDB_PORT: ${MMDB_PORT:-8002}
+      MMDB_SECRET_KEY: ${MMDB_SECRET_KEY}
+      SQL_DATABASE: ${SQL_DATABASE:-prod_mmdb}
+      SQL_HOST: ${SQL_HOST:--tesla.epa.gov}
+      SQL_PORT: ${SQL_PORT:-3306}
+      SQL_USER: ${SQL_USER:-dave}
+      SQL_PASSWORD: ${SQL_PASSWORD}
+      GUNICORN_OPTS: ${GUNICORN_OPTS:-}
+      MMDB_GUNICORN_OPTS: ${GUNICORN_OPTS:-}

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,64 @@
+version: "3.1"
+
+volumes:
+  mmdbstatic:
+
+services:
+  mmdb:
+    image: mmdb
+    restart: unless-stopped
+    environment:
+      ALLOWED_HOSTS: ${ALLOWED_HOSTS}
+      DEBUG: ${DEBUG:-false}
+      MMDB_ALLOWED_HOSTS: ${MMDB_ALLOWED_HOSTS}
+      MMDB_DEBUG: ${MMDB_DEBUG:-false}
+      MMDB_PORT: ${MMDB_PORT:-8002}
+      MMDB_SECRET_KEY: ${MMDB_SECRET_KEY}
+      SQL_DATABASE: ${SQL_DATABASE:-mmdb}
+      SQL_HOST: ${SQL_HOST:-localhost}
+      SQL_PORT: ${SQL_PORT:-3306}
+      SQL_USER: ${SQL_USER:-mmdb}
+      SQL_PASSWORD: ${SQL_PASSWORD:-mmdb}
+      GUNICORN_OPTS: ${GUNICORN_OPTS:-}
+      MMDB_GUNICORN_OPTS: ${GUNICORN_OPTS:-}
+    volumes:
+      - mmdbstatic:/app/collected_static
+
+  nginx:
+    image: nginx:1-alpine
+    restart: unless-stopped
+    ports:
+      - ${MMDB_PORT:-8002}:${MMDB_PORT:-8002}
+    volumes:
+      - mmdbstatic:/app/collected_static:ro
+    depends_on:
+      - mmdb
+    entrypoint: >
+      sh -c "
+        rm /etc/nginx/conf.d/default.conf \
+        && echo \"
+          upstream mmdb {
+              server mmdb:${MMDB_PORT:-8002};
+          }
+          server {
+              listen ${MMDB_PORT:-8002} default_server;
+              server_name _;
+              charset utf-8;
+              client_max_body_size 0;
+              location /static {
+                  alias /app/collected_static;
+              }
+              location /favicon.ico {
+                  access_log off;
+                  log_not_found off;
+              }
+              location / {
+                  proxy_set_header Host \$$http_host;
+                  proxy_pass http://mmdb;
+                  access_log off;
+              }
+          }
+        \" > /etc/nginx/conf.d/default.conf \
+        && exec nginx -g 'daemon off;'
+      "
+

--- a/mmdb/environment.py
+++ b/mmdb/environment.py
@@ -42,6 +42,16 @@ class MetaEnv(type):
         return cls._get("MMDB_VERSION_NUMBER", default)
 
     @property
+    def GUNICORN_OPTS(cls):
+        default = ""
+        return {
+            k: v
+            for entry in cls._get("GUNICORN_OPTS", default, prefix=True).split(",")
+            if entry
+            for k, v in entry.split("=")
+        }
+
+    @property
     def SQL_DATABASE(cls):
         default = "mmdb" if cls.DEBUG else ""
         return cls._get("SQL_DATABASE", default)

--- a/mmdb/gunicorn.py
+++ b/mmdb/gunicorn.py
@@ -1,0 +1,22 @@
+import logging
+import multiprocessing
+
+from mmdb.environment import env
+from mmdb.settings import LOGGING
+
+# Default configuration
+bind = ":" + env.MMDB_PORT
+workers = multiprocessing.cpu_count() * 2 + 1
+logconfig_dict = LOGGING
+access_log_format = '"%(r)s" %(s)s %(b)s'
+
+# Override/set any configuration variable with environment variables
+locals().update(env.GUNICORN_OPTS)
+
+
+def on_starting(server):
+    logger = logging.getLogger("django")
+    if env.DEBUG:
+        logger.warning("Running in DEBUG mode")
+    if "*" in env.ALLOWED_HOSTS:
+        logger.warning("Host checking is disabled (ALLOWED_HOSTS is set to accept all)")

--- a/mmdb/settings/dev.py
+++ b/mmdb/settings/dev.py
@@ -4,6 +4,11 @@ from mmdb.environment import env
 SITE_ID = 1
 DEBUG = True
 
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+STATIC_URL = "/static/"
+STATIC_ROOT = os.path.join(BASE_DIR, "collected_static")
+
 MEDIA_ROOT = os.path.normcase(os.path.dirname(os.path.abspath(__file__)))
 MEDIA_URL = "/media/"
 
@@ -19,7 +24,7 @@ DATABASES = {
         "PORT": env.SQL_PORT,
         "OPTIONS": {
             # Tell MySQLdb to connect with 'utf8mb4' character set
-            "charset": "utf8mb4",
+            "charset": "utf8mb4"
         },
     }
 }
@@ -57,10 +62,56 @@ TEMPLATES = [
                 "django.template.context_processors.static",
                 "django.template.context_processors.tz",
                 "django.contrib.messages.context_processors.messages",
-            ],
+            ]
+        },
+    }
+]
+
+LOGGING = {
+    "version": 1,
+    "formatters": {
+        "console": {
+            "format": "%(asctime)s [%(levelname)s] %(message)s",
+            "datefmt": "[%d/%b/%Y %H:%M:%S]",
+            "class": "logging.Formatter",
+        },
+        "django.server": {
+            "()": "django.utils.log.ServerFormatter",
+            "format": "[{server_time}] [INFO] {message}",
+            "style": "{",
         },
     },
-]
+    "handlers": {
+        "console": {
+            "level": "INFO",
+            "class": "logging.StreamHandler",
+            "formatter": "console",
+        },
+        "django.server": {
+            "level": "INFO",
+            "class": "logging.StreamHandler",
+            "formatter": "django.server",
+        },
+    },
+    "loggers": {
+        "django": {"handlers": ["console"], "level": "INFO", "propagate": False},
+        "django.server": {
+            "handlers": ["django.server"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        "gunicorn.access": {
+            "level": "INFO",
+            "handlers": ["console"],
+            "propagate": False,
+        },
+        "gunicorn.error": {
+            "level": "INFO",
+            "handlers": ["console"],
+            "propagate": False,
+        },
+    },
+}
 
 STATIC_URL = "/static/"
 

--- a/mmdb/wsgi.py
+++ b/mmdb/wsgi.py
@@ -1,0 +1,3 @@
+from django.core.wsgi import get_wsgi_application
+
+application = get_wsgi_application()

--- a/requirements/requirements-env.txt
+++ b/requirements/requirements-env.txt
@@ -1,1 +1,2 @@
 python-dotenv>=0.10.3,<0.11
+gunicorn>=20.0.0,<20.1.0

--- a/template.env
+++ b/template.env
@@ -8,8 +8,8 @@ COMPOSE_PATH_SEPARATOR=;
 #    SQL_PASSWORD=
 # development environment...
 #     COMPOSE_FILE=docker/docker-compose.yaml;docker/docker-compose.dev.override.yaml
-#     SQL_PASSWORD= factotum
-#     SQL_USER= factotum
+#     SQL_PASSWORD=
+#     SQL_USER=
 # MySQL development environment...
 #     COMPOSE_FILE=docker/docker-compose.yaml;docker/docker-compose.dev.override.yaml;docker/docker-compose.mysql.override.yaml
 COMPOSE_FILE=docker/docker-compose.yaml;docker/docker-compose.dev.override.yaml;docker/docker-compose.mysql.override.yaml

--- a/template.env
+++ b/template.env
@@ -1,3 +1,4 @@
+COMPOSE_PROJECT_NAME=mmdb
 COMPOSE_PATH_SEPARATOR=;
 # production environment:
 #    COMPOSE_FILE=docker/docker-compose.yaml;docker/docker-compose.override.yaml


### PR DESCRIPTION
Fixes #2

Created dockerfile and docker-compose/override yaml files to run mmdb/mysql in docker containers. Added gunicorn server and nginx proxy for production environment. The structure is like factotum, where dev and production can override base yaml, and mysql service is an optional add-on. The details are documented in README.
